### PR TITLE
strip carriage return characters from lines

### DIFF
--- a/src/utils/tokenizer/bpe_tokenizer.cpp
+++ b/src/utils/tokenizer/bpe_tokenizer.cpp
@@ -15,7 +15,12 @@ std::vector<std::string> BpeTokenizer::LoadVocab(const std::string& vocab_path) 
     vocab.reserve(50000);
     std::string line;
     while (std::getline(ifs, line)) {
-        if (!line.empty()) vocab.push_back(line);
+        if (!line.empty()) {
+            if (line.back() == '\r') {
+                line.pop_back(); // strip CR
+            }
+            vocab.push_back(line);
+        }
     }
     return vocab;
 }


### PR DESCRIPTION
在windows上，getline会自动去掉`\r\n`
在linux上，getline只会自动去掉`\n`
但是 vocab.txt 可能是 windows `\r\n`，导致linux上加载失败